### PR TITLE
Generate Test Coverage Report with Jacoco

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,7 +61,7 @@ stages:
         steps:
           - checkout: self
           - script: |
-              ./gradlew clean test
+              ./gradlew clean test jacocoTestReport
             displayName: Run Unit Tests
 
   # -------------------------------

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'org.springframework.boot' version '2.7.0-SNAPSHOT'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id 'java'
+    id 'jacoco'
     id 'checkstyle'
 }
 
@@ -56,11 +57,26 @@ checkstyleTest {
     source ='src/test/java'
 }
 
+jacoco {
+    toolVersion = "0.8.11"
+}
+
 test {
     useJUnitPlatform()
 
     filter {
         // exclude all tests containing the `integration` file path or package.
         excludeTestsMatching "*.integration.*"
+    }
+
+    finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+    dependsOn test
+    reports {
+        xml.required = true
+        xml.outputLocation = layout.buildDirectory.file("reports/jacoco/test/jacocoTestReport.xml")
+        html.required = true
     }
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,6 +4,8 @@ sonar.projectKey=jojozhuang_game-store-springboot
 # Optional: coverage, source dirs, etc.
 sonar.sources=src/main/java
 sonar.tests=src/test/java
+sonar.exclusions=src/test/java/**
+sonar.coverage.exclusions=src/test/java/**
 sonar.java.binaries=build/classes/java/main
 sonar.junit.reportPaths=build/test-results/test
 sonar.coverage.jacoco.xmlReportPaths=build/reports/jacoco/test/jacocoTestReport.xml


### PR DESCRIPTION
Enable Jacoco for test coverage report. The report will be generated to `build/reports/jacoco/test/jacocoTestReport.xml` and will be used by Sonar scan.